### PR TITLE
Provide schema_name for tables API

### DIFF
--- a/main.py
+++ b/main.py
@@ -836,7 +836,7 @@ async def superset_database_create(
 @requires_auth
 @handle_api_errors
 async def superset_database_get_tables(
-    ctx: Context, database_id: int
+    ctx: Context, database_id: int, schema_name: Optional[str] = "public"
 ) -> Dict[str, Any]:
     """
     Get a list of tables for a given database
@@ -850,7 +850,13 @@ async def superset_database_get_tables(
     Returns:
         A dictionary with list of tables including schema and table name information
     """
-    return await make_api_request(ctx, "get", f"/api/v1/database/{database_id}/tables/")
+    payload = {
+      "schema_name": schema_name
+    }
+    params = {
+      "q": json.dumps(payload, indent=2)
+    }
+    return await make_api_request(ctx, "get", f"/api/v1/database/{database_id}/tables/", params=params)
 
 
 @mcp.tool()


### PR DESCRIPTION
At https://superset.apache.org/docs/api/ the /tables/ API requires a schema_name to be provided as a json-encoded query parameter, but this is not documented.  Without a schema_name provided the API call will fail.


Let the MCP client provide one, and default to "public"