### PR TITLE
Refactor CLI entry point and add console script

### DIFF
--- a/main.py
+++ b/main.py
@@ -1839,6 +1839,11 @@ async def superset_advanced_data_type_list(ctx: Context) -> Dict[str, Any]:
     return await make_api_request(ctx, "get", "/api/v1/advanced_data_type/types")
 
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for the superset-mcp CLI."""
     logger.info("Starting Superset MCP server...")
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 Homepage = "https://github.com/yourusername/superset-mcp"
 Issues = "https://github.com/yourusername/superset-mcp/issues"
 
+[project.scripts]
+superset-mcp = "main:main"
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- Extract main logic into `main()` function for better structure - Add `superset-mcp` console script to pyproject.toml for easier CLI usage

```shell
uvx --from git+https://github.com/LiusCraft/superset-mcp.git superset-mcp
```